### PR TITLE
Correctly display content when switching tabs in the editor

### DIFF
--- a/src/assetbundles/doxterfield/dist/js/plugin.js
+++ b/src/assetbundles/doxterfield/dist/js/plugin.js
@@ -300,4 +300,12 @@ Doxter.prototype.configure = function (settings)
 Doxter.prototype.render = function ()
 {
     this.editor = new SimpleMDE(this.config);
+    /*
+        Refresh the editor when switching between tabs on the content-editor.
+         More info: https://github.com/selvinortiz/craft-plugin-doxter/issues/14
+    */
+    var self = this;
+    Garnish.$win.on("resize", function () {
+        self.editor.codemirror.refresh();
+    });
 };


### PR DESCRIPTION
Refresh the underlying CodeMirror editor when changing the tab in the content-editor.

Fixes #14, check the Issue for much more information.